### PR TITLE
Fix: Chainlink Oracle staleness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-60ec00296f00754bc21ed68fd05ab6b54b50e024
+          version: nightly-09fe3e041369a816365a020f715ad6f94dbce9f2
 
       - name: Run Forge fmt check
         run: |

--- a/deploy/mainnet.constants.json
+++ b/deploy/mainnet.constants.json
@@ -2,19 +2,31 @@
     "assets": {
         "dai": {
             "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            "priceAggregator": "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9"
+            "priceAggregator": { 
+                "address": "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
+                "timeLimit": 3780 
+            }
         },
         "usdc": {
             "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            "priceAggregator": "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6"
+            "priceAggregator": { 
+                "address": "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6",
+                "timeLimit": 86580
+            }
         },
         "usdt": {
             "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-            "priceAggregator": "0x3E7d1eAB13ad0104d2750B8863b489D65364e32D"
+            "priceAggregator": { 
+                "address": "0x3E7d1eAB13ad0104d2750B8863b489D65364e32D",
+                "timeLimit": 86580
+            }
         },
         "weth": {
             "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-            "priceAggregator": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419"
+            "priceAggregator": { 
+                "address": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+                "timeLimit": 3780 
+            }
         }
     },
     "strategies": {

--- a/deploy/mainnet.contracts.json
+++ b/deploy/mainnet.contracts.json
@@ -74,7 +74,7 @@
     "proxy": "0x6f519d997CD2027F164586718Ca248d2384D7dB1"
   },
   "UsdPriceFeedManager": {
-    "implementation": "0x8fACE55e98eA1AfaA36dD55f3196195a4E61477E",
+    "implementation": "0x08eac676ca5448e55c9fac8619bda1e4a71c93f0",
     "proxy": "0x38f1A78ad8956B45b48837657BD0884BA7AB485A"
   },
   "WithdrawalManager": {

--- a/script/DeploySpool.s.sol
+++ b/script/DeploySpool.s.sol
@@ -216,7 +216,7 @@ contract DeploySpool {
 
         {
             DepositSwap implementation = new DepositSwap(
-                IWETH9(constantsJson().getAddress(".assets.weth")),
+                IWETH9(constantsJson().getAddress(".assets.weth.address")),
                 assetGroupRegistry,
                 smartVaultManager,
                 swapper

--- a/script/mainnet/AssetsInitial.s.sol
+++ b/script/mainnet/AssetsInitial.s.sol
@@ -32,10 +32,13 @@ contract AssetsInitial {
 
         address[] memory assetAddresses = new address[](assetNames.length);
         address[] memory assetPriceAggregators = new address[](assetNames.length);
+        uint256[] memory assetTimeLimits = new uint256[](assetNames.length);
         for (uint256 i; i < assetNames.length; ++i) {
             assetAddresses[i] = constantsJson().getAddress(string.concat(".assets.", assetNames[i], ".address"));
             assetPriceAggregators[i] =
-                constantsJson().getAddress(string.concat(".assets.", assetNames[i], ".priceAggregator"));
+                constantsJson().getAddress(string.concat(".assets.", assetNames[i], ".priceAggregator.address"));
+            assetTimeLimits[i] =
+                constantsJson().getUint256(string.concat(".assets.", assetNames[i], ".priceAggregator.timeLimit"));
         }
 
         assetGroupRegistry.allowTokenBatch(assetAddresses);
@@ -43,7 +46,9 @@ contract AssetsInitial {
         for (uint256 i; i < assetNames.length; ++i) {
             _assets[assetNames[i]] = assetAddresses[i];
 
-            priceFeedManager.setAsset(assetAddresses[i], AggregatorV3Interface(assetPriceAggregators[i]), true);
+            priceFeedManager.setAsset(
+                assetAddresses[i], AggregatorV3Interface(assetPriceAggregators[i]), true, assetTimeLimits[i]
+            );
         }
     }
 

--- a/script/upgrade/UpgradeUsdPriceFeedManager.s.sol
+++ b/script/upgrade/UpgradeUsdPriceFeedManager.s.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.17;
+
+import "../MainnetExtendedSetup.s.sol";
+import "../../src/managers/UsdPriceFeedManager.sol";
+import "@openzeppelin/proxy/transparent/ProxyAdmin.sol";
+import "forge-std/Script.sol";
+
+contract UpgradeUsdPriceFeedManager is MainnetExtendedSetup {
+    function execute() public override {
+        UsdPriceFeedManager implementation = new UsdPriceFeedManager(spoolAccessControl);
+
+        proxyAdmin.upgrade(TransparentUpgradeableProxy(payable(address(usdPriceFeedManager))), address(implementation));
+
+        uint256 daiTimeLimit = constantsJson().getUint256(string.concat(".assets.dai.priceAggregator.timeLimit"));
+        uint256 usdcTimeLimit = constantsJson().getUint256(string.concat(".assets.usdc.priceAggregator.timeLimit"));
+        uint256 usdtTimeLimit = constantsJson().getUint256(string.concat(".assets.usdt.priceAggregator.timeLimit"));
+        uint256 wethTimeLimit = constantsJson().getUint256(string.concat(".assets.weth.priceAggregator.timeLimit"));
+
+        usdPriceFeedManager.updateAssetTimeLimit(_assets["dai"], daiTimeLimit);
+        usdPriceFeedManager.updateAssetTimeLimit(_assets["usdc"], usdcTimeLimit);
+        usdPriceFeedManager.updateAssetTimeLimit(_assets["usdt"], usdtTimeLimit);
+        usdPriceFeedManager.updateAssetTimeLimit(_assets["weth"], wethTimeLimit);
+    }
+}

--- a/test/SmartVaultDeposits.integration.t.sol
+++ b/test/SmartVaultDeposits.integration.t.sol
@@ -44,11 +44,11 @@ contract depositManagerIntegrationTest is Test {
         usdcUsdPriceAggregator = new MockAggregatorV3(8, "Usdc-Usd", 1);
 
         vm.mockCall(daiAddress, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(daiDecimals));
-        usdPriceFeedManager.setAsset(daiAddress, daiUsdPriceAggregator, true);
+        usdPriceFeedManager.setAsset(daiAddress, daiUsdPriceAggregator, true, 1);
         daiUsdPriceAggregator.pushAnswer(1_00000000);
 
         vm.mockCall(usdcAddress, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(usdcDecimals));
-        usdPriceFeedManager.setAsset(usdcAddress, usdcUsdPriceAggregator, true);
+        usdPriceFeedManager.setAsset(usdcAddress, usdcUsdPriceAggregator, true, 1);
         usdcUsdPriceAggregator.pushAnswer(1_00000000);
     }
 


### PR DESCRIPTION
- Remove deprecated staleness check
- Add check for price update within the heartbeat + buffer
- Heartbeat is not present on-chain so we must pass it in `setAsset`. Also add `updateTimeLimit` function to update heartbeat+buffer for existing assets.
- Also update foundry nightly version for CI.